### PR TITLE
Fix failing GitHub tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        poetry install --no-root --with dev --extras "ml"
+        poetry install --no-root --with dev --extras "ml llm"
 
     - name: Run tests
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,11 @@ scipdfparser = "pyscientificpdfparser.cli:main"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.pytest.ini_options]
+pythonpath = [
+    "src"
+]
+
 [tool.black]
 line-length = 88
 target-version = ['py310']

--- a/tests/test_output/arxiv-1410.6579/arxiv-1410.6579.json
+++ b/tests/test_output/arxiv-1410.6579/arxiv-1410.6579.json
@@ -1989,5 +1989,8 @@
       ]
     }
   ],
+  "references": [],
+  "structured_references": null,
+  "extracted_entities": null,
   "llm_processing_log": []
 }


### PR DESCRIPTION
The GitHub Actions CI tests were failing due to two issues:

1.  The `pyscientificpdfparser` module could not be found by pytest because the project uses a `src` layout and the `PYTHONPATH` was not configured correctly. This has been fixed by adding the `pythonpath` to the `pyproject.toml` file.

2.  Tests related to LLM functionality were failing with a `ModuleNotFoundError` because the `llm` optional dependencies were not being installed in the CI environment. This has been fixed by adding the `llm` extra to the `poetry install` command in the `.github/workflows/ci.yml` file.

Additionally, a test fixture JSON file was updated to reflect changes in the parser's output, which was causing a snapshot test to fail.