### PR TITLE
Fix CI warnings and Codecov upload error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,7 @@ jobs:
         poetry run pytest --cov=./ --cov-report=xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         fail_ci_if_error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ build-backend = "poetry.core.masonry.api"
 pythonpath = [
     "src"
 ]
+filterwarnings = [
+    "ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning"
+]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
This commit addresses two issues in the CI workflow:

1.  A `DeprecationWarning` from `PyMuPDF` is suppressed in the pytest configuration (`pyproject.toml`).
2.  The Codecov action is upgraded to `v4` to fix the "Repository not found" error and enable tokenless uploading.