### PR TITLE
Fix Codecov token error in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,6 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
The GitHub Actions workflow was failing because the Codecov action was trying to upload coverage reports for a protected branch ('develop') without an access token.

This change adds the `token` parameter to the Codecov action in the `ci.yml` file, using a GitHub secret (`${{ secrets.CODECOV_TOKEN }}`) to provide the necessary authentication.