### PR TITLE
Fix: Correct PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,11 +25,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel
+        pip install build
 
     - name: Build package
-      run: |
-        python setup.py sdist bdist_wheel
+      run: python -m build
 
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The PyPI publishing workflow was failing because it was using the `python setup.py` command to build the package. This project uses `pyproject.toml` and `poetry`, so `setup.py` does not exist.

This commit updates the workflow to use the modern `python -m build` command to build the package distributions before publishing. It also updates the build dependencies from `setuptools` and `wheel` to `build`.