### PR TITLE
feat: Add develop branch to CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
 jobs:
   build:


### PR DESCRIPTION
The CI workflow was only triggered for the main branch. This change adds the develop branch to the push and pull_request triggers so that the CI workflow runs for the develop branch as well.