### PR TITLE
Fix: Resolve torch installation error in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ pytesseract = "^0.3.10"
 opencv-python-headless = "^4.9.0.80"
 pillow = "^10.3.0"
 # ML/DL
-torch = {version = "^2.6.0", optional = true}
+torch = {version = "^2.6.0", optional = true, source = "pytorch"}
 transformers = {version = "^4.53.0", optional = true}
 # LLM
 langchain-core = {version = "^0.3.0", optional = true}
@@ -51,6 +51,11 @@ isort = "^5.13.2"
 flake8 = "^7.0.0"
 mypy = "^1.10.0"
 pre-commit = "^3.7.0"
+
+[[tool.poetry.source]]
+name = "pytorch"
+url = "https://download.pytorch.org/whl/cpu"
+priority = "explicit"
 
 [tool.poetry.scripts]
 scipdfparser = "pyscientificpdfparser.cli:main"


### PR DESCRIPTION
The GitHub Actions CI was failing on the windows-latest runner during the 'Install dependencies' step. The error was caused by poetry being unable to find a compatible version of the 'torch' package in the default PyPI repository.

This commit fixes the issue by:
1.  Adding a new package source to `pyproject.toml` that points to the official PyTorch wheel repository for CPU-only builds.
2.  Updating the `torch` dependency to explicitly use this new source.

This ensures that poetry can resolve and install the correct version of torch, allowing the CI pipeline to proceed.