### PR TITLE
Fix: Resolve torch installation error in CI for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,13 @@ jobs:
       run: choco install tesseract --yes
 
     - name: Install dependencies
+      if: runner.os != 'Windows'
       run: |
+        poetry install --no-root --with dev --extras "ml llm"
+    - name: Install dependencies on Windows
+      if: runner.os == 'Windows'
+      run: |
+        pip install torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu
         poetry install --no-root --with dev --extras "ml llm"
 
     - name: Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ pytesseract = "^0.3.10"
 opencv-python-headless = "^4.9.0.80"
 pillow = "^10.3.0"
 # ML/DL
-torch = {version = "^2.6.0", optional = true, source = "pytorch"}
+torch = {version = "^2.6.0", optional = true, source = "pytorch", markers = "sys_platform != 'win32'"}
 transformers = {version = "^4.53.0", optional = true}
 # LLM
 langchain-core = {version = "^0.3.0", optional = true}


### PR DESCRIPTION
The GitHub workflow was failing on Windows due to an issue with installing torch using Poetry.

This commit resolves the issue by:
- Installing torch with pip on Windows before other dependencies.
- Adding a marker to the torch dependency in pyproject.toml to exclude it from Poetry's installation process on Windows.