### PR TITLE
Fix: Add Poetry to PATH on Windows in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
+    - name: Add poetry to PATH
+      if: runner.os == 'Windows'
+      run: echo "$APPDATA\pypoetry\venv\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
     - name: Install Tesseract (Linux)
       if: runner.os == 'Linux'
       run: |


### PR DESCRIPTION
The GitHub Actions workflow was failing on the Windows runner because the `poetry` command was not recognized. This was due to the Poetry installation directory not being added to the `PATH` environment variable.

This commit adds a new step to the CI workflow that explicitly adds the Poetry scripts directory to the `PATH` on Windows runners. This ensures that the `poetry` command is available for subsequent steps, allowing the workflow to run successfully on all operating systems.