### PR TITLE
fix(ci): Correct Windows workflow configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
 
     steps:
     - uses: actions/checkout@v3
@@ -27,10 +30,6 @@ jobs:
       with:
         virtualenvs-create: true
         virtualenvs-in-project: true
-
-    - name: Add poetry to PATH
-      if: runner.os == 'Windows'
-      run: echo "$APPDATA\pypoetry\venv\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Install Tesseract (Linux)
       if: runner.os == 'Linux'


### PR DESCRIPTION
The GitHub Actions workflow was failing on Windows because the `poetry` command was not found. This was due to two issues:

1. The default shell for the Windows runner was not set to `bash`, which is required by the `snok/install-poetry` action for cross-platform compatibility.
2. An incorrect and unnecessary step was attempting to add `poetry` to the `PATH` on Windows. The `snok/install-poetry` action handles this automatically.

This commit resolves these issues by:

- Setting the default shell to `bash` for all jobs in the workflow.
- Removing the redundant step that manually modified the `PATH`.