### PR TITLE
Fix(deps): Ensure PDF path is a string for PyMuPDF

### DIFF
--- a/src/pyscientificpdfparser/preprocessing.py
+++ b/src/pyscientificpdfparser/preprocessing.py
@@ -82,7 +82,7 @@ def render_pdf_to_images(
     zoom = dpi / 72  # PyMuPDF uses 72 DPI as the base
     mat = fitz.Matrix(zoom, zoom)
 
-    with fitz.open(pdf_path) as doc:
+    with fitz.open(str(pdf_path)) as doc:
         for page_num, page in enumerate(doc):
             # R1.2: Detect if a page is image-based (scanned)
             # Heuristic: if a page has no extractable text, it's likely scanned.

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -74,4 +74,4 @@ def test_render_pdf_to_images(mock_fitz_open: mock.MagicMock) -> None:
     assert page2.image.size == (10, 10)
 
     # 4. Verify that fitz.open was called correctly
-    mock_fitz_open.assert_called_once_with(dummy_path)
+    mock_fitz_open.assert_called_once_with(str(dummy_path))


### PR DESCRIPTION
The `test_parse_pdf_integration` test was failing on Windows because `fitz.open()` from PyMuPDF was not correctly handling `pathlib.Path` objects.

This commit fixes the issue by converting the `pathlib.Path` object to a string before passing it to `fitz.open()`. This ensures cross-platform compatibility.

The test `test_render_pdf_to_images` was also updated to reflect this change.