### PR TITLE
Fix Windows CI test failure by setting Tesseract path.

### DIFF
--- a/src/pyscientificpdfparser/dla.py
+++ b/src/pyscientificpdfparser/dla.py
@@ -41,10 +41,14 @@ class LayoutAnalyzer:
                 AutoModelForObjectDetection.from_pretrained(model_name)
             )
             self.model.eval()  # Set model to evaluation mode
-        except OSError:
+        except Exception as e:
+            print(f"CRITICAL: Failed to load LayoutAnalyzer model '{model_name}'.")
+            print(f"CRITICAL: Error details: {e}")
             print(
-                f"Could not load model '{model_name}'. "
-                "Ensure you have an internet connection."
+                "CRITICAL: Document Layout Analysis will be skipped. "
+                "This may be due to a missing internet connection, "
+                "a problem with the Tesseract installation, or other "
+                "dependency issues."
             )
             # Handle model loading failure gracefully
             self.processor = None

--- a/src/pyscientificpdfparser/ocr.py
+++ b/src/pyscientificpdfparser/ocr.py
@@ -9,6 +9,7 @@ Responsibilities:
 """
 from __future__ import annotations
 
+import platform
 from collections import defaultdict
 from typing import TypedDict
 
@@ -16,6 +17,14 @@ import pytesseract
 
 from .models import BoundingBox, TextBlock
 from .preprocessing import PreprocessedPage
+
+
+# R2.4: Add OS-specific path for Tesseract on Windows
+if platform.system() == "Windows":
+    # Default path for Tesseract installed via Chocolatey on GitHub Actions
+    pytesseract.pytesseract.tesseract_cmd = (
+        r"C:\Program Files\Tesseract-OCR\tesseract.exe"
+    )
 
 
 class OcrBlock(TypedDict):


### PR DESCRIPTION
The `test_parse_pdf_integration` test was failing on the Windows GitHub Actions runner because the `LayoutAnalyzer` model was not being loaded. This caused the document layout analysis step to be skipped, resulting in no sections being parsed from the test PDF.

The root cause is likely that `pytesseract`, a dependency of the Hugging Face processor for the layout model, could not find the Tesseract executable on the Windows runner's default PATH.

This commit fixes the issue by explicitly setting the `pytesseract.tesseract_cmd` to the default Chocolatey installation location for Tesseract on Windows.

Additionally, more detailed error logging has been added to the `LayoutAnalyzer`'s initialization to make it easier to diagnose similar issues in the future.